### PR TITLE
Support XDG_CONFIG_HOME settings for config dirs

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,8 +17,8 @@ Check out this repository:
 
 Create configuration file with SOUNDDIR pointing to the directory including the sound files:
 
-   : mkdir -p ${HOME}/.config/commit-sounds/
-   : echo "SOUNDDIR=\"${BASEPATH}/commit-sounds/sounds/\"" >> ${HOME}/.config/commit-sounds/defaults
+   : mkdir -p ${XDG_CONFIG_HOME:-${HOME}/.config}/commit-sounds/
+   : echo "SOUNDDIR=\"${BASEPATH}/commit-sounds/sounds/\"" >> ${XDG_CONFIG_HOME:-${HOME}/.config}/commit-sounds/defaults
 
 Create a test repository for playing around:
 

--- a/git/hooks/commit-msg
+++ b/git/hooks/commit-msg
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-${HOME}/.config}
+
 # config needs to set $SOUNDDIR
-if [ -r "${HOME}/.config/commit-sounds/defaults" ] ; then
-  . "${HOME}/.config/commit-sounds/defaults"
+if [ -r "${XDG_CONFIG_HOME}/commit-sounds/defaults" ] ; then
+  . "${XDG_CONFIG_HOME}/commit-sounds/defaults"
 fi
 
 if [ -z "${SOUNDDIR}" ] ; then
   echo "NOTE: .git/hooks/commit-msg is inactive, since SOUNDDIR is unset."
-  echo "NOTE: To activate commit-sounds edit ${HOME}/.config/commit-sounds/defaults"
+  echo "NOTE: To activate commit-sounds edit ${XDG_CONFIG_HOME}/commit-sounds/defaults"
   exit 0
 fi
 


### PR DESCRIPTION
First things first.  I absolutely love the idea of this!  Should make crunch time a little more interesting.  Back to pull request...

The [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) gives us the opportunity to set a custom location for config file, these quick patches add support for those of who hate `~/.config` ;)

I split the patches up to make it easier for you to cherry pick, if you'd like to pull support in to the script but keep the `README.org` a little clearer.  Those of us who set alternative values for `XDG_CONFIG_HOME` may well read the ``~/.config` as "where I like my configs" already.

Thanks,

James

PS.  Yes, I realise I've managed to make two commits that don't trigger a sound :P
